### PR TITLE
Enable esModuleInterop

### DIFF
--- a/configs/tsconfig.base.json
+++ b/configs/tsconfig.base.json
@@ -9,7 +9,7 @@
     "strict": true,
     "noImplicitAny": true,
     "declaration": true,
-    "importHelpers": true,
+    "importHelpers": false,
     "lib": [ "es2017", "dom" ],
     "types": ["node"]
   }

--- a/configs/tsconfig.base.json
+++ b/configs/tsconfig.base.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "allowJs": false,
+    "esModuleInterop": true,
     "target": "es2017",
     "module": "commonjs",
     "moduleResolution": "node",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-flyway",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-flyway",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "ISC",
       "dependencies": {
         "auto-bind": "4.0.0",

--- a/src/cli/download/download-provider.ts
+++ b/src/cli/download/download-provider.ts
@@ -1,4 +1,4 @@
-import * as decompress from "decompress";
+import decompress from "decompress";
 import {mkdir, rm, stat} from "fs/promises";
 import {FlywayVersion} from "../../internal/flyway-version";
 import {hasFullPermissionsOnFile} from "../../utility/utility";

--- a/src/cli/download/download-provider.ts
+++ b/src/cli/download/download-provider.ts
@@ -4,9 +4,9 @@ import {FlywayVersion} from "../../internal/flyway-version";
 import {hasFullPermissionsOnFile} from "../../utility/utility";
 import {FlywayCliProvider} from "../flyway-cli-provider";
 // @ts-ignore - fix missing types
-import * as decompressTargz from "decompress-targz";
+import decompressTargz from "decompress-targz";
 // @ts-ignore - fix missing types
-import * as decompressUnzip from "decompress-unzip";
+import decompressUnzip from "decompress-unzip";
 import {resolve} from "path";
 import {FlywayCliSource} from "../../types/types";
 import {getLogger} from "../../utility/logger";

--- a/src/cli/download/self-cleaning-download-provider.ts
+++ b/src/cli/download/self-cleaning-download-provider.ts
@@ -1,4 +1,4 @@
-import * as _temp from "temp";
+import _temp from "temp";
 import { FlywayVersion } from "../../internal/flyway-version";
 import { FlywayCli } from "../flyway-cli";
 import { FlywayCliProvider } from "../flyway-cli-provider";

--- a/src/flyway.ts
+++ b/src/flyway.ts
@@ -11,7 +11,7 @@ import {
     NodeFlywayResponse
 } from "./response/responses";
 import {ExecutionOptions, FlywayAdvancedConfig, FlywayConfig, FlywayOptionalConfig} from "./types/types";
-import * as autoBind from "auto-bind";
+import autoBind from "auto-bind";
 import {enableLogging} from "./utility/logger";
 
 export class Flyway {

--- a/src/utility/logger.ts
+++ b/src/utility/logger.ts
@@ -1,4 +1,4 @@
-import * as debug from "debug";
+import debug from "debug";
 
 
 export type Logger = {

--- a/test/unit/cli/download/flyway-cli-download-provider.test.ts
+++ b/test/unit/cli/download/flyway-cli-download-provider.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { stat } from "fs/promises";
 import { describe } from "mocha";
 import { join } from "path";
-import * as _temp from "temp";
+import _temp from "temp";
 import { DownloadProvider } from "../../../../src/cli/download/download-provider";
 import { FlywayVersion } from "../../../../src";
 import { MockFlywayCliDownloader } from "../../utility/mock-flyway-cli-downloader";
@@ -73,7 +73,7 @@ describe("FlywayCliDownloadProvider", () => {
         
         let error;
         try {
-            stat(join(temporaryDirectory, mockFlywayCliDownloader.getCompressedFlywayCliFileName()));
+            await stat(join(temporaryDirectory, mockFlywayCliDownloader.getCompressedFlywayCliFileName()));
         }
         catch (err) {
             error = err;


### PR DESCRIPTION
This is necessary as the definition files of some dependencies use synthetic default imports.