### PR TITLE
Refactor and fix path separator weirdness

### DIFF
--- a/src/cli/download/download-provider.ts
+++ b/src/cli/download/download-provider.ts
@@ -107,6 +107,7 @@ export class DownloadProvider extends FlywayCliProvider {
         if(files.length == 0) {
             throw new Error("Weird. Expected some files to be extracted.");
         }
+        // TODO - ensure this works on Windows OS
         return path.join(outerDirectory, files[0].path.split(path.sep)[0]);
     }
 

--- a/src/cli/download/download-provider.ts
+++ b/src/cli/download/download-provider.ts
@@ -83,7 +83,7 @@ export class DownloadProvider extends FlywayCliProvider {
 
         await rm(archiveLocation, {force: true});
         
-        const executable = await FlywayCliService.getExecutableFromFlywayCli(extractedDirectory);
+        const executable = await FlywayCliService.getExecutableFromFlywayCliDirectory(extractedDirectory);
 
         const hash = await FlywayCliService.getFlywayCliHash(extractedDirectory);
 

--- a/src/cli/filesystem/short-circuit-file-system-provider.ts
+++ b/src/cli/filesystem/short-circuit-file-system-provider.ts
@@ -37,7 +37,7 @@ export class ShortCircuitFileSystemFlywayCliProvider extends FlywayCliProvider {
             );
         }
 
-        const executable = await FlywayCliService.getExecutableFromFlywayCli(this.directory);
+        const executable = await FlywayCliService.getExecutableFromFlywayCliDirectory(this.directory);
 
         ShortCircuitFileSystemFlywayCliProvider.logger.log(
             `Successfully found a Flyway CLI with path: ${this.directory} using the optimized local CLI strategy.`

--- a/src/cli/flyway-cli-provider.ts
+++ b/src/cli/flyway-cli-provider.ts
@@ -9,6 +9,10 @@ export abstract class FlywayCliProvider {
 
     public abstract getFlywayCli(flywayVersion: FlywayVersion) : Promise<FlywayCli | undefined>
 
+    /*
+        Used to chain providers together in a fluent interface.
+        Multiple strategies can be used to attempt to source a Flyway CLI until one is successful.
+     */
     public chain(provider: FlywayCliProvider): FlywayCliProvider {
         
         return {


### PR DESCRIPTION
- Improves naming conventions in the services locating a Flyway installation.
- Adds contextual comments
- Replaces hard-coded path separators with system agnostic `path.sep`.