### PR TITLE
Always quote command line option strings - Resolves domdinnes/node-flyway#29

### DIFF
--- a/src/internal/flyway-command-line-options.ts
+++ b/src/internal/flyway-command-line-options.ts
@@ -1,5 +1,6 @@
 import {isMap} from "util/types";
 import {CommandLineOptionMap, FlywayAdvancedConfig, FlywayBasicConfig, FlywayConfig} from "../types/types";
+import {platform} from "os";
 
 
 
@@ -46,10 +47,8 @@ class FlywayCommandLineStandardOption implements FlywayCommandLineOption {
     }
 
     convertToCommandLineString(): string {
-        const commandLineOptionValue = this.commandLineOptionValue.includes(" ")
-            ? `"${this.commandLineOptionValue}"`
-            : this.commandLineOptionValue;
-        return `-${this.commandLineOptionKey}=${commandLineOptionValue}`;
+        const quote = platform() === "win32" ? '"' : "'";
+        return `-${this.commandLineOptionKey}=${quote}${this.commandLineOptionValue}${quote}`;
     }
 }
 
@@ -63,7 +62,8 @@ class FlywayCommandLineArrayOption<T> implements FlywayCommandLineOption {
     }
 
     convertToCommandLineString(): string {
-        return `-${this.commandLineOptionKey}="${this.commandLineOptionValues.join(",")}"`;
+        const quote = platform() === "win32" ? '"' : "'";
+        return `-${this.commandLineOptionKey}=${quote}${this.commandLineOptionValues.join(',')}${quote}`;
     }
 
 }
@@ -78,10 +78,11 @@ class FlywayCommandLineMapOption implements FlywayCommandLineOption {
 
     convertToCommandLineString(): string {
         const commandLineStringParts: string[] = [];
+        const quote = platform() === 'win32' ? '"' : "'";
 
         // Throw if keys include whitespace
         this.commandLineOptionMapValues.forEach((key, val) => {
-            commandLineStringParts.push(`${this.commandLineOptionKey}.${key}="${val}"`);
+            commandLineStringParts.push(`${this.commandLineOptionKey}.${key}=${quote}${val}${quote}`);
         });
 
         return commandLineStringParts.join(" ");

--- a/test/integration/migrate.test.ts
+++ b/test/integration/migrate.test.ts
@@ -270,7 +270,7 @@ describe("migrate()", () => {
         The desired behaviour is that this should be escaped and treated as a string literal.
 
      */
-    xit('can migrate a schema when configuration contains shell-expansion characters', async () => {
+    it('can migrate a schema when configuration contains shell-expansion characters', async () => {
 
         // Given
         // ... the schemas property includes a shell variable

--- a/test/unit/internal/flyway-command-line-options.test.ts
+++ b/test/unit/internal/flyway-command-line-options.test.ts
@@ -16,15 +16,15 @@ describe("CommandLineOptionGenerator", () => {
 
         const result = FlywayCommandLineOptions.build(config);
 
-        expect(result.getCommandLineOptions()).to.contains.members(
-            [
-                '-url=test-url',
-                '-user=test-user',
-                '-locations="dir_1,dir_2"'
-            ]
-        );
-
         expect(result.getCommandLineOptions()).to.have.length(3);
+
+        result.getCommandLineOptions().forEach((option, i) => {
+            expect(option).to.match([
+                /^-url=['"]test-url['"]$/,
+                /^-user=['"]test-user['"]$/,
+                /^-locations=['"]dir_1,dir_2['"]$/
+            ][i]);
+        });
     });
 
 
@@ -46,20 +46,21 @@ describe("CommandLineOptionGenerator", () => {
 
         const result = FlywayCommandLineOptions.build(config);
 
-        expect(result.getCommandLineOptions()).to.contains.members(
-            [
-                '-url=test-url',
-                '-user=test-user',
-                '-locations="dir_1,dir_2"',
-                '-createSchemas=true',
-                '-outOfOrder=true',
-                '-sqlMigrationPrefix=V__',
-                '-initSql="CREATE TABLE random.some_table (id INTEGER PRIMARY KEY, some_column TEXT NOT NULL);"',
-                '-group=true'
-            ]
-        );
-
         expect(result.getCommandLineOptions()).to.have.length(8);
+
+        result.getCommandLineOptions().forEach((option, i) => {
+            expect(option).to.match([
+                /^-url=['"]test-url['"]$/,
+                /^-user=['"]test-user['"]$/,
+                /^-locations=['"]dir_1,dir_2['"]$/,
+                /^-createSchemas=['"]true['"]$/,
+                /^-outOfOrder=['"]true['"]$/,
+                /^-sqlMigrationPrefix=['"]V__['"]$/,
+                /^-initSql=['"]CREATE TABLE random.some_table \(id INTEGER PRIMARY KEY, some_column TEXT NOT NULL\);['"]$/,
+                /^-group=['"]true['"]$/
+            ][i]);
+        });
+
     });
 
 
@@ -78,18 +79,19 @@ describe("CommandLineOptionGenerator", () => {
 
         const result = FlywayCommandLineOptions.build(config);
 
-        expect(result.getCommandLineOptions()).to.contains.members(
-            [
-                '-url=test-url',
-                '-user=test-user',
-                '-locations="dir_1,dir_2"',
-                '-createSchemas=true',
-                '-defaultSchema=public',
-                '-schemas="example"'
-            ]
-        );
 
         expect(result.getCommandLineOptions()).to.have.length(6);
+
+        result.getCommandLineOptions().forEach((option, i) => {
+            expect(option).to.match([
+                /^-url=['"]test-url['"]$/,
+                /^-user=['"]test-user['"]$/,
+                /^-defaultSchema=['"]public['"]$/,
+                /^-locations=['"]dir_1,dir_2['"]$/,
+                /^-createSchemas=['"]true['"]$/,
+                /^-schemas=['"]example['"]$/
+            ][i]);
+        });
     });
 
 
@@ -109,18 +111,18 @@ describe("CommandLineOptionGenerator", () => {
 
         const result = FlywayCommandLineOptions.build(config);
 
-        expect(result.getCommandLineOptions()).to.contains.members(
-            [
-                '-url=jdbc:postgresql://localhost:2575/postgres',
-                '-user=postgres',
-                '-password=password123',
-                '-defaultSchema=public',
-                '-locations="test/integration/migrations/1_basic_migrations"',
-                '-cleanDisabled=false'
-            ]
-        );
-
         expect(result.getCommandLineOptions()).to.have.length(6);
+
+        result.getCommandLineOptions().forEach((option, i) => {
+            expect(option).to.match([
+                /^-url=['"]jdbc:postgresql:\/\/localhost:2575\/postgres['"]$/,
+                /^-user=['"]postgres['"]$/,
+                /^-password=['"]password123['"]$/,
+                /^-defaultSchema=['"]public['"]$/,
+                /^-locations=['"]test\/integration\/migrations\/1_basic_migrations['"]$/,
+                /^-cleanDisabled=['"]false['"]$/,
+            ][i]);
+        });
     });
 
 


### PR DESCRIPTION
### Description

This pull request addresses issue [#29](https://github.com/domdinnes/node-flyway/issues/29) by ensuring that command line option strings are always quoted. This update enhances the handling of options containing spaces or special characters, ensuring consistent behavior across different environments.

### Key Changes

1. **Command Line Options Quoting:**
   - Updated the quoting mechanism in `src/internal/flyway-command-line-options.ts` to use appropriate quotes based on the platform (single quotes for Unix-based systems and double quotes for Windows).

2. **Tests Adjustments:**
   - Modified related integration and unit tests in `test/integration/migrate.test.ts` and `test/unit/internal/flyway-command-line-options.test.ts` to align with the new quoting logic.

### Context

The changes ensure that all command line options are correctly interpreted by the system, resolving issues where options with spaces or special characters were previously mishandled.
