### PR TITLE
Log input string when JSON parsing fails (fixes domdinnes#32)

### DIFF
--- a/src/response/json-to-response.ts
+++ b/src/response/json-to-response.ts
@@ -26,6 +26,9 @@ export class ConvertJsonToResponse {
         }
         catch (err) {
             ConvertJsonToResponse.logger.log(err);
+            if (err instanceof SyntaxError) {
+                ConvertJsonToResponse.logger.log(json);
+            } 
         }
 
 


### PR DESCRIPTION
## Fix: Add Logging for Unparseable JSON Responses

### Description

This PR addresses [issue #32](https://github.com/domdinnes/node-flyway/issues/32), which reports errors when users run commands through the wrapper, resulting in unparseable JSON responses.

### Changes Made

- **Error Handling**: Added logging for unparseable JSON responses to aid in troubleshooting.
  - Modified the first `JSON.parse` attempt to log the raw response if a `SyntaxError` is caught.
