### PR TITLE
Fix issue preventing migration when old archive exists

### DIFF
--- a/src/cli/download/downloader/flyway-cli-downloader.ts
+++ b/src/cli/download/downloader/flyway-cli-downloader.ts
@@ -1,8 +1,13 @@
-import { join } from "path";
-import { FlywayVersion, getUrlComponentsForFlywayVersion } from "../../../internal/flyway-version";
+import {join} from "path";
+import {FlywayVersion, getUrlComponentsForFlywayVersion} from "../../../internal/flyway-version";
 import {DownloaderHelper} from "node-downloader-helper";
 import {getLogger, Logger} from "../../../utility/logger";
-import {getHostOperatingSystem, OperatingSystem, getHostCpuArchitecture, CpuArchitecture} from "../../../utility/utility";
+import {
+    CpuArchitecture,
+    getHostCpuArchitecture,
+    getHostOperatingSystem,
+    OperatingSystem
+} from "../../../utility/utility";
 
 /*
     Takes a flyway version and a save directory.
@@ -11,6 +16,11 @@ import {getHostOperatingSystem, OperatingSystem, getHostCpuArchitecture, CpuArch
 */
 
 export interface FlywayCliDownloader {
+
+    getFlywayCliDownloadLocation(
+        flywayVersion: FlywayVersion,
+        saveDirectory: string
+    ): string
 
     downloadFlywayCli(
         flywayVersion: FlywayVersion, 
@@ -28,11 +38,20 @@ export class DirectFlywayCliDownloader implements FlywayCliDownloader {
         flywayVersion: FlywayVersion,
         saveDirectory: string
     ): Promise<string> {
-        const operatingSystem = getHostOperatingSystem();
-        const cpuArchitecture = getHostCpuArchitecture();
-        const url = FlywayCliUrlBuilder.buildUrl(flywayVersion, operatingSystem, cpuArchitecture);
+        const url = this.buildUrl(flywayVersion);
         await this.download(url.url, saveDirectory);
         return join(saveDirectory, url.fileName);
+    }
+
+    getFlywayCliDownloadLocation(flywayVersion: FlywayVersion, saveDirectory: string): string {
+        const url = this.buildUrl(flywayVersion);
+        return join(saveDirectory, url.fileName);
+    }
+
+    private buildUrl(flywayVersion: FlywayVersion): FlywayCliUrl {
+        const operatingSystem = getHostOperatingSystem();
+        const cpuArchitecture = getHostCpuArchitecture();
+        return FlywayCliUrlBuilder.buildUrl(flywayVersion, operatingSystem, cpuArchitecture);
     }
 
     private async download(url: string, saveDirectory: string): Promise<void> {
@@ -53,16 +72,17 @@ export class DirectFlywayCliDownloader implements FlywayCliDownloader {
 
 }
 
-
+export type FlywayCliUrl = {
+    url: string, fileName: string
+};
 
 export class FlywayCliUrlBuilder {
-
 
     public static buildUrl(
         flywayVersion: FlywayVersion,
         operatingSystem: OperatingSystem,
         cpuArchitecture: CpuArchitecture
-    ): {url: string, fileName: string} {
+    ): FlywayCliUrl  {
         const urlComponents = getUrlComponentsForFlywayVersion(flywayVersion);
         const fileName = this.buildFilename(flywayVersion, operatingSystem, cpuArchitecture);
         
@@ -100,5 +120,11 @@ export class MavenFlywayCliDownloader implements FlywayCliDownloader {
     ): Promise<string> {
         throw new Error("Method not implemented.");
     }
+
+    getFlywayCliDownloadLocation(flywayVersion: FlywayVersion, saveDirectory: string): string {
+        throw new Error("Method not implemented.");
+    }
+
+
 
 }

--- a/test/unit/utility/mock-flyway-cli-downloader.ts
+++ b/test/unit/utility/mock-flyway-cli-downloader.ts
@@ -7,20 +7,22 @@ export class MockFlywayCliDownloader implements FlywayCliDownloader {
         
     private compressedFilename: string = "test-flyway-commandline-8.5.0-macosx-x64.tar.gz";
 
-
     public async downloadFlywayCli(
         flywayVersion: FlywayVersion, 
         saveDirectory: string
     ): Promise<string> {
         // Test will only run on mac
-
         if(flywayVersion != FlywayVersion["V8.5.0"]) {
             throw new Error();
         }
         const path = "./test/unit/resources";
-        const destinationPath = join(saveDirectory, this.compressedFilename);
+        const destinationPath = this.getFlywayCliDownloadLocation(flywayVersion, saveDirectory);
         await copyFile(join(path, this.compressedFilename), destinationPath);
         return destinationPath;
+    }
+
+    public getFlywayCliDownloadLocation(flywayVersion: FlywayVersion, saveDirectory: string): string {
+        return join(saveDirectory, this.compressedFilename);
     }
 
     public getCompressedFlywayCliFileName(): string {


### PR DESCRIPTION
Addresses an issue where partially completed/duplicate downloads which haven't been cleaned up will cause an error to occur. This typically happens when one or more download attempts are interrupted, leaving incomplete files in the download directory.
The first download attempt will leave a file with name `flyway-cli-X.X.X.tar.gz`, the second `flyway-cli-X.X.X.tar.gz (1)` and so on. When the next complete download happens, the process will fail at the extract stage as the extraction url will reference an incorrect url. The url of the completed download will be: `flyway-cli-X.X.X.tar.gz (2)` whereas the extraction url will reference flyway-cli-X.X.X.tar.gz which refers to the first incomplete download.

This fix cleans up any downloaded archives with a matching filename in the target directory before downloading another flyway version.