### PR TITLE
Fix convertJsonToResponse error when array property value is undefined

### DIFF
--- a/src/response/json-to-response.ts
+++ b/src/response/json-to-response.ts
@@ -171,7 +171,12 @@ function transform(val: any, typ: any, getProps: any, key: any = ''): any {
 
     function transformArray(typ: any, val: any): any {
         // val must be an array with no invalid elements
-        if (!Array.isArray(val)) return invalidValue("array", val);
+        if (!Array.isArray(val)) {
+            if (val === null || val === undefined) {
+                return val;
+            }
+            return invalidValue("array", val);
+        }
         return val.map(el => transform(el, typ, getProps));
     }
 


### PR DESCRIPTION
@domdinnes this should fix #41 , but if you don't like this fix, I can also look into making sure that `warnings` gets set to an empty array instead of `undefined` (during `info`)