### PR TITLE
Always parse flyway -outputType=json CLI output from stdout, never stderr (#1)

### DIFF
--- a/src/utility/utility.ts
+++ b/src/utility/utility.ts
@@ -81,20 +81,21 @@ export type ExecutionResponse = {
 }
 
 
-export const execute = async (command: string, options: ExecOptions): Promise<ExecutionResponse> => {
+export const execute = async (
+    command: string,
+    options: ExecOptions,
+    execFn: typeof exec = exec
+): Promise<ExecutionResponse> => {
     return new Promise((resolve, reject) => {
         try {
-            exec(
+            execFn(
                 command,
                 options,
                 (err, stdout, stderr) => {
-                    if (err == null) {
-                        resolve(
-                            {success: true, response: stdout.toString()}
-                        );
-                    } else {
-                        resolve({success: false, response: stderr.toString()});
-                    }
+                  resolve(
+                        // When run with `-outputType=json`, flyway always writes errors to `stdout`, never `stderr`.
+                        {success: err === null, response: stdout.toString()}
+                    );
                 }
             )
         } catch (error) {

--- a/test/unit/utility/utility.test.ts
+++ b/test/unit/utility/utility.test.ts
@@ -1,0 +1,83 @@
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {execute} from '../../../src/utility/utility';
+import {ExecOptions} from 'node:child_process';
+
+describe('execute', () => {
+    it('should parse stdout even when process exits with failure', async () => {
+        // Mock exec function that simulates a failed process with JSON output in stdout
+        const mockExec = (
+            command: string,
+            options: ExecOptions,
+            callback: (error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void
+        ) => {
+            const error = new Error('Command failed with exit code 1') as any;
+            error.code = 1;
+
+            const jsonOutput = JSON.stringify({
+                "error": {
+                    "errorCode": "ERROR",
+                    "message": "Migration failed",
+                    "stackTrace": null,
+                    "lineNumber": null,
+                    "path": null,
+                },
+            });
+
+            // Simulate process failure but with JSON output in stdout
+            callback(error, jsonOutput, '');
+
+            return {} as any; // Return mock ChildProcess
+        };
+
+        const result = await execute('flyway migrate -outputType=json', {}, mockExec as any);
+
+        expect(result.success).to.be.false;
+        expect(result.response).to.equal(JSON.stringify({
+            "error": {
+                "errorCode": "ERROR",
+                "message": "Migration failed",
+                "stackTrace": null,
+                "lineNumber": null,
+                "path": null,
+            },
+        }));
+    });
+
+    it('should parse stdout when process exits successfully', async () => {
+        // Mock exec function that simulates a successful process
+        const mockExec = (
+            command: string,
+            options: ExecOptions,
+            callback: (error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void
+        ) => {
+            const jsonOutput = JSON.stringify({
+                "initialSchemaVersion": "1",
+                "targetSchemaVersion": null,
+                "schemaName": "",
+                "migrations": [],
+                "success": true,
+                "operation": "migrate",
+                "migrationsExecuted": 0
+            });
+
+            // Simulate successful execution
+            callback(null, jsonOutput, '');
+
+            return {} as any; // Return mock ChildProcess
+        };
+
+        const result = await execute('flyway migrate -outputType=json', {}, mockExec as any);
+
+        expect(result.success).to.be.true;
+        expect(result.response).to.equal(JSON.stringify({
+            "initialSchemaVersion": "1",
+            "targetSchemaVersion": null,
+            "schemaName": "",
+            "migrations": [],
+            "success": true,
+            "operation": "migrate",
+            "migrationsExecuted": 0
+        }));
+    });
+});


### PR DESCRIPTION
From [the flyway docs](https://github.com/flyway/flywaydb.org/blob/gh-pages/documentation/usage/commandline/index.md#machine-readable-output):

> Add -outputType=json to the argument list to print JSON instead of human-readable output. Errors are included in the JSON payload instead of being sent to stderr.

On failure, `node-flyway` currently always tries to parse JSON from `stderr`, but `flyway -outputType=json` always writes its errors (as JSON) to `stdout`. This causes https://github.com/domdinnes/node-flyway/issues/41 .

This fixes the issue by always parsing `stdout`, regardless of whether or not the process exits successfully.

Fixes #41 .